### PR TITLE
fix issue with torch.tensor->numpy.ndarray conversion

### DIFF
--- a/run.py
+++ b/run.py
@@ -141,7 +141,7 @@ def main():
             log_metrics(args=args, log=log, iteration=i, design_sampler=design_sampler)
            
             # save log_p_means and rosettas
-            logmeans.append(design_sampler.log_p_mean)
+            logmeans.append(design_sampler.log_p_mean.item())
             rosettas.append(design_sampler.rosetta_energy)
         
             if design_sampler.log_p_mean < best_energy:


### PR DESCRIPTION
log_p_mean is a single value but can be a cuda tensor still attached to the computational graph. This breaks numpy conversion in l.164. 
`log_p_mean.item()` gets rid of this problem. 

Tested with torch 1.8.2 LTS